### PR TITLE
Add dialog length logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ The XP memory values for the main game and Bad Blood are the same, but they are 
 2. A line id can be searched in cheat engine when a specific line is said in the game. Look for the memory address that changes line ids after each line is said/shown. Add that to your addresslist and pointer scan. 
 3. Repeat step 2 (Rescan once to narrow down on a lone pointer path with the last offset being 20). 
 
+## Line ID indexes (for line log)
+The line log line ID addresses are different, as they reset to -1 when the dialog is finished, which is necessary for timing the dialog length. We only use the first 2 indexes, since 3 or more dialogs playing at once is extremely rare.
+1. Go to the second room in the intro, where the "Chicago Police--if there's anybody in here, identify yourselves." dialog occurs.
+2. Use the list of line IDs to search for the line as it appears. It should change to `FFFFFFFF` (-1 if signed int) when the lines finish. This is `lineIdIdx0`. Its offsets are `0x8, 0x30`.
+3. Reload autosave and run to the room to the right to make the "Got a body here. Definitely a Viceroy. Here's the weapon, gunshot wounds--" dialog stack on the first one. Search for its line IDs to find `lineIdIdx1`. Its offsets are `0x8, 0x70`.
+
 ### Ending Variable
 This is a static address that changes in value from 0 to 1 when you shoot Damien, but it does not only change value for that instance. It is used along with ```lineid``` to split at the ending of WD1 when you shoot Damien. 
 

--- a/WD1MainMissionAutoSplitter.asl
+++ b/WD1MainMissionAutoSplitter.asl
@@ -20,6 +20,10 @@ state("Watch_Dogs" , "v1.04.497")
 	int ending: "Disrupt_b64.dll", 0x393EB78;
 	
 	int loading: "Disrupt_b64.dll", 0x39562CC;	
+
+	int lineIdIdx0: "Disrupt_b64.dll", 0x3940438, 0x8, 0x30;
+
+	int lineIdIdx1: "Disrupt_b64.dll", 0x3940438, 0x8, 0x70;
 }
 
 state("Watch_Dogs" , "v1.06.329 Steam Latest")
@@ -40,6 +44,9 @@ state("Watch_Dogs" , "v1.06.329 Steam Latest")
 	
 	int loading: "Disrupt_b64.dll", 0x3B7BAFC;
 	
+	int lineIdIdx0: "Disrupt_b64.dll", 0x3B5CAB8, 0x8, 0x30;
+
+	int lineIdIdx1: "Disrupt_b64.dll", 0x3B5CAB8, 0x8, 0x70;
 }
 
 state("Watch_Dogs" , "v1.06.329 Uplay Latest")
@@ -59,13 +66,18 @@ state("Watch_Dogs" , "v1.06.329 Uplay Latest")
 	int ending: "Disrupt_b64.dll", 0x3B76B28;
 	
 	int loading: "Disrupt_b64.dll", 0x3B94ACC;
-	
+
+	int lineIdIdx0: "Disrupt_b64.dll", 0x3B784F8, 0x8, 0x30;
+
+	int lineIdIdx1: "Disrupt_b64.dll", 0x3B784F8, 0x8, 0x70;
 }
 
 
 startup{
 
     vars.stopwatch = new Stopwatch();
+    vars.line0Stopwatch = new Stopwatch();
+    vars.line1Stopwatch = new Stopwatch();
     
     settings.Add ("CTOS Control Centers", false, "CTOS Control Centers");
     settings.SetToolTip("CTOS Control Centers", "Splits after completing a ctOS control center.");
@@ -82,6 +94,9 @@ startup{
     
     settings.Add("Remember", false, "Remember");
     settings.SetToolTip("Remember", "Splits after the cemetery cutscene in Act 1");
+
+    settings.Add("Log Dialog", false, "Log Dialog");
+    settings.SetToolTip("Log Dialog", "Log line IDs and their duration in milliseconds as they occurred in the run to LineLog.txt next to your LiveSplit.exe");
    
     
     Action<string> logDebug = (text) => {
@@ -119,6 +134,43 @@ startup{
 		return !isDoubleSplit;
 	};
 	vars.isNotDoubleSplit = isNotDoubleSplit;
+
+	Action<string> logLine = (text) => {
+		vars.logDebug("Writing line: " + text);
+		if (vars.lineLogFile == null) {
+			vars.lineLogFile = File.Open("LineLog.txt", FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
+		}
+		byte[] line = new UTF8Encoding(true).GetBytes(text + "\r\n");
+		vars.lineLogFile.Write(line, 0, line.Length);
+	};
+	vars.lineLogFile = null;
+	vars.logLine = logLine;
+
+	Action<int, int, Stopwatch> detectLineChange = (oldLineId, newLineId, stopwatch) => {
+		// if (oldLineId != newLineId) {
+		// 	vars.logDebug("oldLineId:" + oldLineId + " newLineId:" + newLineId);
+		// }
+
+		if (oldLineId <= 0 && newLineId > 0) {
+			// no dialog -> dialog
+			stopwatch.Restart();
+		} else if (oldLineId > 0 && newLineId == -1) {
+			// dialog -> no dialog
+			vars.logLine(oldLineId + "\t" + stopwatch.ElapsedMilliseconds);
+		} else if (oldLineId != newLineId && oldLineId > 0 && newLineId > 0) {
+			// Dialog -> different dialog
+			vars.logLine(oldLineId + "\t" + stopwatch.ElapsedMilliseconds);
+			stopwatch.Restart();
+		}	
+	};
+	vars.detectLineChange = detectLineChange;
+}
+
+shutdown
+{
+	if (vars.lineLogFile != null) {
+		vars.lineLogFile.Close();
+	}
 }
 
 init{
@@ -155,6 +207,12 @@ update{
 
         if(vars.stopwatch.ElapsedMilliseconds > 10000)
 	    vars.stopwatch.Reset();
+
+		if(settings["Log Dialog"]) {
+			vars.detectLineChange(old.lineIdIdx0, current.lineIdIdx0, vars.line0Stopwatch);
+			vars.detectLineChange(old.lineIdIdx1, current.lineIdIdx1, vars.line1Stopwatch);
+		}
+		
 }
 
 
@@ -163,15 +221,22 @@ start{
 	if(vars.stopwatch.ElapsedMilliseconds > 2000)
 	    vars.stopwatch.Reset();
 
-        if(current.lineid == 46209)
-	{
-        vars.stopwatch.Start();
-	    if(vars.stopwatch.ElapsedMilliseconds > 300)    //Aiden Story Start
-		return true;
-    	}
+        if(current.lineid == 46209) {
+			vars.stopwatch.Start();
+			if(vars.stopwatch.ElapsedMilliseconds > 300) {  //Aiden Story Start
+				if(settings["Log Dialog"]) {
+					vars.logLine("### Starting new run ###");
+				}
+				return true;
+			}
+		}
 		
 	if(current.lineid == 10004649)   //Bad Blood Start
+		if(settings["Log Dialog"]) {
+			vars.logLine("### Starting new run ###");
+		}
 		return true;
+
 }
 
 


### PR DESCRIPTION
- Times the length of each line ID encountered in a run, and logs it to a file.
- Enabled behind "Log Dialog" setting.